### PR TITLE
Issue with parsing of ingredients where description has prefix 'a'

### DIFF
--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -268,7 +268,9 @@ class Ingreedy(NodeVisitor):
         = "touches"
         / "touch"
 
-        number
+        number = written_number space
+
+        written_number
         = "a"
         / "an"
         / "zero"
@@ -371,6 +373,9 @@ class Ingreedy(NodeVisitor):
         return self.res
 
     def visit_number(self, node, visited_children):
+        return visited_children[0]
+
+    def visit_written_number(self, node, visited_children):
         return number_value[node.text]
 
     def generic_visit(self, node, visited_children):

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -197,6 +197,11 @@ test_cases = {
         'ingredient': 'vanilla ice cream',
         'unit': 'ounce',
     },
+    'apple': {
+        'amount': None,
+        'ingredient': 'apple',
+        'unit': None,
+    },
 }
 
 


### PR DESCRIPTION
The string `a` is also a `number` [token](https://github.com/openculinary/ingreedy-py/blob/0011e2d843d1677dba22a856d8850e4afed91a5f/ingreedypy.py#L8), and the definition of [ingredient-addition](https://github.com/openculinary/ingreedy-py/blob/0011e2d843d1677dba22a856d8850e4afed91a5f/ingreedypy.py#L76) states that a space is *optional* after an amount token.

This results in situations where the parser will consume the first letter as a number from any word beginning with `a`.