### PR TITLE
Allow wordbreaks to consist of spaces or commas

### DIFF
--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -73,7 +73,7 @@ class Ingreedy(NodeVisitor):
 
     grammar = Grammar(
         """
-        ingredient_addition = amount? space? (unit)? space? alternative_amount? space? container? (unit)? space? ingredient?
+        ingredient_addition = amount? break? (unit)? break? alternative_amount? break? container? (unit)? break? ingredient?
 
         amount
         = float
@@ -83,20 +83,21 @@ class Ingreedy(NodeVisitor):
         / number
 
         alternative_amount
-        = ~"[/]" space? container
+        = ~"[/]" break? container
 
-        space
+        break
         = " "
+        / comma
         / ~"[\t]"
 
         separator
-        = space
+        = break
         / "-"
 
         ingredient
-        = (word (comma? space word)* ~".*")
+        = (word (break word)* ~".*")
 
-        container = open? amount "-"? space? unit close?
+        container = open? amount "-"? break? unit close?
 
         open = "("
         close = ")"
@@ -149,7 +150,7 @@ class Ingreedy(NodeVisitor):
         / "c"
 
         fluid_ounce
-        = fluid space ounce
+        = fluid break ounce
 
         fluid
         = "fluid"
@@ -268,7 +269,7 @@ class Ingreedy(NodeVisitor):
         = "touches"
         / "touch"
 
-        number = written_number space
+        number = written_number break
 
         written_number
         = "a"

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -202,6 +202,11 @@ test_cases = {
         'ingredient': 'apple',
         'unit': None,
     },
+    '3-⅝ ounces, weight feta cheese, crumbled/diced': {
+        'amount': 3.625,
+        'ingredient': 'weight feta cheese, crumbled/diced',
+        'unit': 'ounce'
+    }
 }
 
 


### PR DESCRIPTION
This is an incremental improvement to allow some edge cases to succeed.

In particular, the presence of commas anywhere other than inside matched ingredient text will currently cause a failure.

By redefining the `space` token between words as a `break` token, which allows either spaces or commas, we can allow these to succeed without impairing existing parsing.