### PR TITLE
Support multipart quantities

### DIFF
--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -78,25 +78,25 @@ class Ingreedy(NodeVisitor):
         = amount_with_units
         / amount
 
-        translated_quantity
-        = open amount break unit close
+        parenthesized_quantity
+        = open amount break? unit close
 
         alternative_quantity
         = ~"[/]" break? (ignored_amount? break? unit? break?)+
 
         amount_with_units
-        = amount_with_multiplier
+        = amount_with_conversion
         / amount_with_attached_units
-        / amount_with_translation
+        / amount_with_multiplier
 
-        amount_with_multiplier
-        = amount break? unit break translated_quantity
+        amount_with_conversion
+        = amount break? unit break parenthesized_quantity
 
         amount_with_attached_units
         = amount break? unit break
 
-        amount_with_translation
-        = amount break? translated_quantity
+        amount_with_multiplier
+        = amount break? parenthesized_quantity
 
         amount
         = float
@@ -429,17 +429,17 @@ class Ingreedy(NodeVisitor):
     def visit_amount_with_units(self, node, visited_children):
         return visited_children[0]
 
-    def visit_amount_with_multiplier(self, node, visited_children):
-        _, multiplier = visited_children[0]
-        unit, amount = visited_children[2]
-        return unit, amount * multiplier
+    def visit_amount_with_conversion(self, node, visited_children):
+        _, amount = visited_children[0]
+        unit, _ = visited_children[2]
+        return unit, amount
 
     def visit_amount_with_attached_units(self, node, visited_children):
         _, amount = visited_children[0]
         unit, _ = visited_children[2]
         return unit, amount
 
-    def visit_amount_with_translation(self, node, visited_children):
+    def visit_amount_with_multiplier(self, node, visited_children):
         _, multiplier = visited_children[0]
         unit, amount = visited_children[2]
         return unit, amount * multiplier
@@ -447,7 +447,7 @@ class Ingreedy(NodeVisitor):
     def visit_unit(self, node, visited_children):
         return visited_children[0], 1
 
-    def visit_translated_quantity(self, node, visited_children):
+    def visit_parenthesized_quantity(self, node, visited_children):
         _, amount = visited_children[1]
         unit, _ = visited_children[3]
         return unit, amount

--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -177,6 +177,7 @@ class Ingreedy(NodeVisitor):
         fluid
         = "fluid"
         / "fl."
+        / "fl"
 
         gallon
         = "gallons"

--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -75,10 +75,13 @@ class Ingreedy(NodeVisitor):
         ingredient_addition = (quantity break?)* alternative_quantity? break? ingredient
 
         quantity
+        = quantity_with_units
+        / amount
+
+        quantity_with_units
         = (amount break? unit break? translated_quantity)
-        / (amount break? translated_quantity)
         / (amount break? unit)
-        / (amount)
+        / (amount break? translated_quantity)
 
         translated_quantity
         = open ignored_amount break unit close

--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -87,9 +87,6 @@ class Ingreedy(NodeVisitor):
         / amount_with_attached_units
         / amount_with_multiplier
 
-        parenthesized_quantity
-        = open amount break? unit !letter close
-
         amount_with_conversion
         = amount break? unit !letter break parenthesized_quantity
 
@@ -98,6 +95,9 @@ class Ingreedy(NodeVisitor):
 
         amount_with_multiplier
         = amount break? parenthesized_quantity
+
+        parenthesized_quantity
+        = open amount_with_attached_units close
 
         single_unit
         = unit !letter
@@ -431,8 +431,7 @@ class Ingreedy(NodeVisitor):
         return visited_children[0], 1
 
     def visit_parenthesized_quantity(self, node, visited_children):
-        _, amount = visited_children[1]
-        unit, _ = visited_children[3]
+        unit, amount = visited_children[1]
         return unit, amount
 
     def visit_ingredient_addition(self, node, visited_children):

--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -75,7 +75,10 @@ class Ingreedy(NodeVisitor):
         ingredient_addition = (quantity break?)* alternative_quantity? break? ingredient
 
         quantity
-        = amount break? unit? break? translated_quantity?
+        = (amount break? unit break? translated_quantity)
+        / (amount break? translated_quantity)
+        / (amount break? unit)
+        / (amount)
 
         translated_quantity
         = open ignored_amount break unit close

--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -72,23 +72,23 @@ class Ingreedy(NodeVisitor):
 
     grammar = Grammar(
         """
-        ingredient_addition = (quantity break?)* alternative_quantity? break? ingredient
+        ingredient_addition = (quantity_fragment break?)* alternative_quantity? break? ingredient
 
-        quantity
-        = amount_with_units
+        quantity_fragment
+        = quantity
         / amount
-        / implied_amount
-
-        parenthesized_quantity
-        = open amount break? unit !letter close
+        / single_unit
 
         alternative_quantity
-        = ~"[/]" break? (amount? break? (unit !letter)? break?)+
+        = ~"[/]" break? (quantity break?)*
 
-        amount_with_units
+        quantity
         = amount_with_conversion
         / amount_with_attached_units
         / amount_with_multiplier
+
+        parenthesized_quantity
+        = open amount break? unit !letter close
 
         amount_with_conversion
         = amount break? unit !letter break parenthesized_quantity
@@ -99,7 +99,7 @@ class Ingreedy(NodeVisitor):
         amount_with_multiplier
         = amount break? parenthesized_quantity
 
-        implied_amount
+        single_unit
         = unit !letter
 
         amount
@@ -393,7 +393,7 @@ class Ingreedy(NodeVisitor):
     def visit_float(self, node, visited_children):
         return float(node.text)
 
-    def visit_quantity(self, node, visited_children):
+    def visit_quantity_fragment(self, node, visited_children):
         unit, amount = visited_children[0]
         if not self.res['quantity']:
             self.res['quantity'] = []
@@ -405,7 +405,7 @@ class Ingreedy(NodeVisitor):
     def visit_amount(self, node, visited_children):
         return None, sum(visited_children)
 
-    def visit_amount_with_units(self, node, visited_children):
+    def visit_quantity(self, node, visited_children):
         return visited_children[0]
 
     def visit_amount_with_conversion(self, node, visited_children):
@@ -423,7 +423,7 @@ class Ingreedy(NodeVisitor):
         unit, amount = visited_children[2]
         return unit, amount * multiplier
 
-    def visit_implied_amount(self, node, visited_children):
+    def visit_single_unit(self, node, visited_children):
         unit, _ = visited_children[0]
         return unit, 1
 

--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -87,12 +87,15 @@ class Ingreedy(NodeVisitor):
         / amount_with_attached_units
         / amount_with_multiplier
 
+        # 4lb (900g)
         amount_with_conversion
         = amount break? unit !letter break parenthesized_quantity
 
+        # 1 kg
         amount_with_attached_units
         = amount break? unit !letter
 
+        # two (five ounce)
         amount_with_multiplier
         = amount break? parenthesized_quantity
 

--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -75,7 +75,7 @@ class Ingreedy(NodeVisitor):
         / single_unit
 
         alternative_quantity
-        = ~"[/]" break? (quantity break?)*
+        = ~"[/]" break? multipart_quantity
 
         quantity
         = amount_with_conversion

--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -77,6 +77,7 @@ class Ingreedy(NodeVisitor):
         quantity
         = amount_with_units
         / amount
+        / implied_amount
 
         parenthesized_quantity
         = open amount break? unit !letter close
@@ -97,6 +98,9 @@ class Ingreedy(NodeVisitor):
 
         amount_with_multiplier
         = amount break? parenthesized_quantity
+
+        implied_amount
+        = unit !letter
 
         amount
         = float
@@ -418,6 +422,10 @@ class Ingreedy(NodeVisitor):
         _, multiplier = visited_children[0]
         unit, amount = visited_children[2]
         return unit, amount * multiplier
+
+    def visit_implied_amount(self, node, visited_children):
+        unit, _ = visited_children[0]
+        return unit, 1
 
     def visit_unit(self, node, visited_children):
         return visited_children[0], 1

--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -82,7 +82,7 @@ class Ingreedy(NodeVisitor):
         = open amount break? unit close
 
         alternative_quantity
-        = ~"[/]" break? (ignored_amount? break? unit? break?)+
+        = ~"[/]" break? (amount? break? unit? break?)+
 
         amount_with_units
         = amount_with_conversion
@@ -99,13 +99,6 @@ class Ingreedy(NodeVisitor):
         = amount break? parenthesized_quantity
 
         amount
-        = float
-        / mixed_number
-        / fraction
-        / integer
-        / number
-
-        ignored_amount
         = float
         / mixed_number
         / fraction

--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -79,10 +79,10 @@ class Ingreedy(NodeVisitor):
         / amount
 
         parenthesized_quantity
-        = open amount break? unit close
+        = open amount break? unit !letter close
 
         alternative_quantity
-        = ~"[/]" break? (amount? break? unit? break?)+
+        = ~"[/]" break? (amount? break? (unit !letter)? break?)+
 
         amount_with_units
         = amount_with_conversion
@@ -90,10 +90,10 @@ class Ingreedy(NodeVisitor):
         / amount_with_multiplier
 
         amount_with_conversion
-        = amount break? unit break parenthesized_quantity
+        = amount break? unit !letter break parenthesized_quantity
 
         amount_with_attached_units
-        = amount break? unit break
+        = amount break? unit !letter
 
         amount_with_multiplier
         = amount break? parenthesized_quantity

--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -391,31 +391,12 @@ class Ingreedy(NodeVisitor):
 
     def visit_quantity(self, node, visited_children):
         unit, amount = visited_children[0]
-        result = self.res['quantity']
-
-        # If no quantity has been discovered so far, store this node's values
-        if result is None:
-            self.res['quantity'] = {'unit': unit, 'amount': amount}
-
-        # If quantity results are a list, append this node's values
-        elif isinstance(result, list):
-            self.res['quantity'] += {'unit': unit, 'amount': amount}
-
-        # If no units had been found so far, establish a multiplied quantity
-        elif result['unit'] is None:
-            result['unit'] = unit
-            result['amount'] *= amount
-
-        # If the result is of the same unit, sum the amount with this node
-        elif result['unit'] == unit:
-            result['amount'] += amount
-
-        # An existing quantity of a different unit was found; create a list
-        else:
-            self.res['quantity'] = [
-                self.res['quantity'],
-                {'unit': unit, 'amount': amount}
-            ]
+        if not self.res['quantity']:
+            self.res['quantity'] = []
+        elif self.res['quantity'][0]['unit'] is None:
+            amount *= self.res['quantity'][0]['amount']
+            self.res['quantity'] = []
+        self.res['quantity'].append({'unit': unit, 'amount': amount})
 
     def visit_amount(self, node, visited_children):
         return None, sum(visited_children)

--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -411,7 +411,6 @@ class Ingreedy(NodeVisitor):
         return unit, system, amount
 
     def visit_amount_with_attached_units(self, node, visited_children):
-        print(visited_children)
         _, _, amount = visited_children[0]
         unit, system, _ = visited_children[2]
         return unit, system, amount

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -9,294 +9,336 @@ test_cases = {
     '1.0 cup flour': {
         'quantity': [{
             'amount': 1.0,
-            'unit': 'cup'
+            'unit': 'cup',
+            'unit_type': 'english',
         }],
         'ingredient': 'flour',
     },
     '1 1/2 cups flour': {
         'quantity': [{
             'amount': 1.5,
-            'unit': 'cup'
+            'unit': 'cup',
+            'unit_type': 'english',
         }],
         'ingredient': 'flour',
     },
     '1 1/2 potatoes': {
         'quantity': [{
             'amount': 1.5,
-            'unit': None
+            'unit': None,
+            'unit_type': None,
         }],
         'ingredient': 'potatoes',
     },
     '12345 potatoes': {
         'quantity': [{
             'amount': 12345,
-            'unit': None
+            'unit': None,
+            'unit_type': None,
         }],
         'ingredient': 'potatoes',
     },
     '1 2/3 cups flour': {
         'quantity': [{
             'amount': round(float(5.0/3), 3),
-            'unit': 'cup'
+            'unit': 'cup',
+            'unit_type': 'english',
         }],
         'ingredient': 'flour',
     },
     '12 (6-ounce) boneless skinless chicken breasts': {
         'quantity': [{
             'amount': 72,
-            'unit': 'ounce'
+            'unit': 'ounce',
+            'unit_type': 'english',
         }],
         'ingredient': 'boneless skinless chicken breasts',
     },
     '1 (28 ounce) can crushed tomatoes': {
         'quantity': [{
             'amount': 28,
-            'unit': 'ounce'
+            'unit': 'ounce',
+            'unit_type': 'english',
         }],
         'ingredient': 'can crushed tomatoes',
     },
     '1/2 cups flour': {
         'quantity': [{
             'amount': 0.5,
-            'unit': 'cup'
+            'unit': 'cup',
+            'unit_type': 'english',
         }],
         'ingredient': 'flour',
     },
     '12g potatoes': {
         'quantity': [{
             'amount': 12,
-            'unit': 'gram'
+            'unit': 'gram',
+            'unit_type': 'metric',
         }],
         'ingredient': 'potatoes',
     },
     '12oz potatoes': {
         'quantity': [{
             'amount': 12,
-            'unit': 'ounce'
+            'unit': 'ounce',
+            'unit_type': 'english',
         }],
         'ingredient': 'potatoes',
     },
     '12oz tequila': {
         'quantity': [{
             'amount': 12,
-            'unit': 'ounce'
+            'unit': 'ounce',
+            'unit_type': 'english',
         }],
         'ingredient': 'tequila',
     },
     '1/2 potato': {
         'quantity': [{
             'amount': 0.5,
-            'unit': None
+            'unit': None,
+            'unit_type': None,
         }],
         'ingredient': 'potato',
     },
     '1.5 cups flour': {
         'quantity': [{
             'amount': 1.5,
-            'unit': 'cup'
+            'unit': 'cup',
+            'unit_type': 'english',
         }],
         'ingredient': 'flour',
     },
     '1.5 potatoes': {
         'quantity': [{
             'amount': 1.5,
-            'unit': None
+            'unit': None,
+            'unit_type': None,
         }],
         'ingredient': 'potatoes',
     },
     '1 clove garlic, minced': {
         'quantity': [{
             'amount': 1,
-            'unit': None
+            'unit': None,
+            'unit_type': None,
         }],
         'ingredient': 'clove garlic, minced',
     },
     '1 cup flour': {
         'quantity': [{
             'amount': 1,
-            'unit': 'cup'
+            'unit': 'cup',
+            'unit_type': 'english',
         }],
         'ingredient': 'flour',
     },
     '1 garlic clove, sliced in 1/2': {
         'quantity': [{
             'amount': 1,
-            'unit': None
+            'unit': None,
+            'unit_type': None,
         }],
         'ingredient': 'garlic clove, sliced in 1/2',
     },
     '1 tablespoon (3 teaspoons) Sazon seasoning blend (recommended: Goya) with Mexican and Spanish foods in market': {
         'quantity': [{
             'amount': 1,
-            'unit': 'tablespoon'
+            'unit': 'tablespoon',
+            'unit_type': 'english',
         }],
         'ingredient': 'Sazon seasoning blend (recommended: Goya) with Mexican and Spanish foods in market',
     },
     '2 (28 ounce) can crushed tomatoes': {
         'quantity': [{
             'amount': 56,
-            'unit': 'ounce'
+            'unit': 'ounce',
+            'unit_type': 'english',
         }],
         'ingredient': 'can crushed tomatoes',
     },
     '.25 cups flour': {
         'quantity': [{
             'amount': 0.25,
-            'unit': 'cup'
+            'unit': 'cup',
+            'unit_type': 'english',
         }],
         'ingredient': 'flour',
     },
     '2 cups of potatoes': {
         'quantity': [{
             'amount': 2,
-            'unit': 'cup'
+            'unit': 'cup',
+            'unit_type': 'english',
         }],
         'ingredient': 'potatoes',
     },
     '2 eggs, beaten': {
         'quantity': [{
             'amount': 2,
-            'unit': None
+            'unit': None,
+            'unit_type': None,
         }],
         'ingredient': 'eggs, beaten',
     },
     '3 28 ounce cans of crushed tomatoes': {
         'quantity': [{
             'amount': 84,
-            'unit': 'ounce'
+            'unit': 'ounce',
+            'unit_type': 'english',
         }],
         'ingredient': 'cans of crushed tomatoes',
     },
     '5 3/4 pinches potatoes': {
         'quantity': [{
             'amount': 5.75,
-            'unit': 'pinch'
+            'unit': 'pinch',
+            'unit_type': 'imprecise',
         }],
         'ingredient': 'potatoes',
     },
     '.5 potatoes': {
         'quantity': [{
             'amount': 0.5,
-            'unit': None
+            'unit': None,
+            'unit_type': None,
         }],
         'ingredient': 'potatoes',
     },
     'a cup of flour': {
         'quantity': [{
             'amount': 1,
-            'unit': 'cup'
+            'unit': 'cup',
+            'unit_type': 'english',
         }],
         'ingredient': 'flour',
     },
     'ground black pepper to taste': {
-        'quantity': None,
+        'quantity': [],
         'ingredient': 'ground black pepper to taste',
     },
     'one 28 ounce can crushed tomatoes': {
         'quantity': [{
             'amount': 28,
-            'unit': 'ounce'
+            'unit': 'ounce',
+            'unit_type': 'english',
         }],
         'ingredient': 'can crushed tomatoes',
     },
     'one cup flour': {
         'quantity': [{
             'amount': 1,
-            'unit': 'cup'
+            'unit': 'cup',
+            'unit_type': 'english',
         }],
         'ingredient': 'flour',
     },
     'three 28 ounce cans crushed tomatoes': {
         'quantity': [{
             'amount': 84,
-            'unit': 'ounce'
+            'unit': 'ounce',
+            'unit_type': 'english',
         }],
         'ingredient': 'cans crushed tomatoes',
     },
     'two 28 ounce cans crushed tomatoes': {
         'quantity': [{
             'amount': 56,
-            'unit': 'ounce'
+            'unit': 'ounce',
+            'unit_type': 'english',
         }],
         'ingredient': 'cans crushed tomatoes',
     },
     'two five ounce can crushed tomatoes': {
         'quantity': [{
             'amount': 10,
-            'unit': 'ounce'
+            'unit': 'ounce',
+            'unit_type': 'english',
         }],
         'ingredient': 'can crushed tomatoes',
     },
     '1kg / 2lb 4oz potatoes': {
         'quantity': [{
             'amount': 1,
-            'unit': 'kilogram'
+            'unit': 'kilogram',
+            'unit_type': 'metric',
         }],
         'ingredient': 'potatoes',
     },
     '2lb 4oz potatoes': {
         'quantity': [{
             'amount': 2,
-            'unit': 'pound'
+            'unit': 'pound',
+            'unit_type': 'english',
         }, {
             'amount': 4,
-            'unit': 'ounce'
+            'unit': 'ounce',
+            'unit_type': 'english',
         }],
         'ingredient': 'potatoes',
     },
     '2lb 4oz (1kg) potatoes': {
         'quantity': [{
             'amount': 2,
-            'unit': 'pound'
+            'unit': 'pound',
+            'unit_type': 'english',
         }, {
             'amount': 4,
-            'unit': 'ounce'
+            'unit': 'ounce',
+            'unit_type': 'english',
         }],
         'ingredient': 'potatoes',
     },
     '1-1/2 ounce vanilla ice cream': {
         'quantity': [{
             'amount': 1.5,
-            'unit': 'ounce'
+            'unit': 'ounce',
+            'unit_type': 'english',
         }],
         'ingredient': 'vanilla ice cream',
     },
     '1-½ ounce vanilla ice cream': {
         'quantity': [{
             'amount': 1.5,
-            'unit': 'ounce'
+            'unit': 'ounce',
+            'unit_type': 'english',
         }],
         'ingredient': 'vanilla ice cream',
     },
     'apple': {
-        'quantity': None,
+        'quantity': [],
         'ingredient': 'apple',
     },
     '3-⅝ ounces, weight feta cheese, crumbled/diced': {
         'quantity': [{
             'amount': 3.625,
-            'unit': 'ounce'
+            'unit': 'ounce',
+            'unit_type': 'english',
         }],
         'ingredient': 'weight feta cheese, crumbled/diced',
     },
     '16-ounce can of sliced pineapple': {
         'quantity': [{
             'amount': 16,
-            'unit': 'ounce'
+            'unit': 'ounce',
+            'unit_type': 'english',
         }],
         'ingredient': 'can of sliced pineapple',
     },
     '750ml/1 pint 7fl oz hot vegetable stock': {
         'quantity': [{
             'amount': 750,
-            'unit': 'milliliter'
+            'unit': 'milliliter',
+            'unit_type': 'metric',
         }],
         'ingredient': 'hot vegetable stock',
     },
     'pinch salt': {
         'quantity': [{
             'amount': 1,
-            'unit': 'pinch'
+            'unit': 'pinch',
+            'unit_type': 'imprecise',
         }],
         'ingredient': 'salt',
     },

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -293,6 +293,13 @@ test_cases = {
         }],
         'ingredient': 'hot vegetable stock',
     },
+    'pinch salt': {
+        'quantity': [{
+            'amount': 1,
+            'unit': 'pinch'
+        }],
+        'ingredient': 'salt',
+    },
 }
 
 

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -7,185 +7,185 @@ from ingreedypy import Ingreedy
 
 test_cases = {
     '1.0 cup flour': {
-        'quantity': {
+        'quantity': [{
             'amount': 1.0,
             'unit': 'cup'
-        },
+        }],
         'ingredient': 'flour',
     },
     '1 1/2 cups flour': {
-        'quantity': {
+        'quantity': [{
             'amount': 1.5,
             'unit': 'cup'
-        },
+        }],
         'ingredient': 'flour',
     },
     '1 1/2 potatoes': {
-        'quantity': {
+        'quantity': [{
             'amount': 1.5,
             'unit': None
-        },
+        }],
         'ingredient': 'potatoes',
     },
     '12345 potatoes': {
-        'quantity': {
+        'quantity': [{
             'amount': 12345,
             'unit': None
-        },
+        }],
         'ingredient': 'potatoes',
     },
     '1 2/3 cups flour': {
-        'quantity': {
+        'quantity': [{
             'amount': round(float(5.0/3), 3),
             'unit': 'cup'
-        },
+        }],
         'ingredient': 'flour',
     },
     '12 (6-ounce) boneless skinless chicken breasts': {
-        'quantity': {
+        'quantity': [{
             'amount': 72,
             'unit': 'ounce'
-        },
+        }],
         'ingredient': 'boneless skinless chicken breasts',
     },
     '1 (28 ounce) can crushed tomatoes': {
-        'quantity': {
+        'quantity': [{
             'amount': 28,
             'unit': 'ounce'
-        },
+        }],
         'ingredient': 'can crushed tomatoes',
     },
     '1/2 cups flour': {
-        'quantity': {
+        'quantity': [{
             'amount': 0.5,
             'unit': 'cup'
-        },
+        }],
         'ingredient': 'flour',
     },
     '12g potatoes': {
-        'quantity': {
+        'quantity': [{
             'amount': 12,
             'unit': 'gram'
-        },
+        }],
         'ingredient': 'potatoes',
     },
     '12oz potatoes': {
-        'quantity': {
+        'quantity': [{
             'amount': 12,
             'unit': 'ounce'
-        },
+        }],
         'ingredient': 'potatoes',
     },
     '12oz tequila': {
-        'quantity': {
+        'quantity': [{
             'amount': 12,
             'unit': 'ounce'
-        },
+        }],
         'ingredient': 'tequila',
     },
     '1/2 potato': {
-        'quantity': {
+        'quantity': [{
             'amount': 0.5,
             'unit': None
-        },
+        }],
         'ingredient': 'potato',
     },
     '1.5 cups flour': {
-        'quantity': {
+        'quantity': [{
             'amount': 1.5,
             'unit': 'cup'
-        },
+        }],
         'ingredient': 'flour',
     },
     '1.5 potatoes': {
-        'quantity': {
+        'quantity': [{
             'amount': 1.5,
             'unit': None
-        },
+        }],
         'ingredient': 'potatoes',
     },
     '1 clove garlic, minced': {
-        'quantity': {
+        'quantity': [{
             'amount': 1,
             'unit': None
-        },
+        }],
         'ingredient': 'clove garlic, minced',
     },
     '1 cup flour': {
-        'quantity': {
+        'quantity': [{
             'amount': 1,
             'unit': 'cup'
-        },
+        }],
         'ingredient': 'flour',
     },
     '1 garlic clove, sliced in 1/2': {
-        'quantity': {
+        'quantity': [{
             'amount': 1,
             'unit': None
-        },
+        }],
         'ingredient': 'garlic clove, sliced in 1/2',
     },
     '1 tablespoon (3 teaspoons) Sazon seasoning blend (recommended: Goya) with Mexican and Spanish foods in market': {
-        'quantity': {
+        'quantity': [{
             'amount': 1,
             'unit': 'tablespoon'
-        },
+        }],
         'ingredient': 'Sazon seasoning blend (recommended: Goya) with Mexican and Spanish foods in market',
     },
     '2 (28 ounce) can crushed tomatoes': {
-        'quantity': {
+        'quantity': [{
             'amount': 56,
             'unit': 'ounce'
-        },
+        }],
         'ingredient': 'can crushed tomatoes',
     },
     '.25 cups flour': {
-        'quantity': {
+        'quantity': [{
             'amount': 0.25,
             'unit': 'cup'
-        },
+        }],
         'ingredient': 'flour',
     },
     '2 cups of potatoes': {
-        'quantity': {
+        'quantity': [{
             'amount': 2,
             'unit': 'cup'
-        },
+        }],
         'ingredient': 'potatoes',
     },
     '2 eggs, beaten': {
-        'quantity': {
+        'quantity': [{
             'amount': 2,
             'unit': None
-        },
+        }],
         'ingredient': 'eggs, beaten',
     },
     '3 28 ounce cans of crushed tomatoes': {
-        'quantity': {
+        'quantity': [{
             'amount': 84,
             'unit': 'ounce'
-        },
+        }],
         'ingredient': 'cans of crushed tomatoes',
     },
     '5 3/4 pinches potatoes': {
-        'quantity': {
+        'quantity': [{
             'amount': 5.75,
             'unit': 'pinch'
-        },
+        }],
         'ingredient': 'potatoes',
     },
     '.5 potatoes': {
-        'quantity': {
+        'quantity': [{
             'amount': 0.5,
             'unit': None
-        },
+        }],
         'ingredient': 'potatoes',
     },
     'a cup of flour': {
-        'quantity': {
+        'quantity': [{
             'amount': 1,
             'unit': 'cup'
-        },
+        }],
         'ingredient': 'flour',
     },
     'ground black pepper to taste': {
@@ -193,73 +193,79 @@ test_cases = {
         'ingredient': 'ground black pepper to taste',
     },
     'one 28 ounce can crushed tomatoes': {
-        'quantity': {
+        'quantity': [{
             'amount': 28,
             'unit': 'ounce'
-        },
+        }],
         'ingredient': 'can crushed tomatoes',
     },
     'one cup flour': {
-        'quantity': {
+        'quantity': [{
             'amount': 1,
             'unit': 'cup'
-        },
+        }],
         'ingredient': 'flour',
     },
     'three 28 ounce cans crushed tomatoes': {
-        'quantity': {
+        'quantity': [{
             'amount': 84,
             'unit': 'ounce'
-        },
+        }],
         'ingredient': 'cans crushed tomatoes',
     },
     'two 28 ounce cans crushed tomatoes': {
-        'quantity': {
+        'quantity': [{
             'amount': 56,
             'unit': 'ounce'
-        },
+        }],
         'ingredient': 'cans crushed tomatoes',
     },
     'two five ounce can crushed tomatoes': {
-        'quantity': {
+        'quantity': [{
             'amount': 10,
             'unit': 'ounce'
-        },
+        }],
         'ingredient': 'can crushed tomatoes',
     },
     '1kg / 2lb 4oz potatoes': {
-        'quantity': {
+        'quantity': [{
             'amount': 1,
             'unit': 'kilogram'
-        },
+        }],
         'ingredient': 'potatoes',
     },
     '2lb 4oz potatoes': {
-        'quantity': [
-            {'amount': 2, 'unit': 'pound'},
-            {'amount': 4, 'unit': 'ounce'},
-        ],
+        'quantity': [{
+            'amount': 2,
+            'unit': 'pound'
+        }, {
+            'amount': 4,
+            'unit': 'ounce'
+        }],
         'ingredient': 'potatoes',
     },
     '2lb 4oz (1kg) potatoes': {
-        'quantity': [
-            {'amount': 2, 'unit': 'pound'},
-            {'amount': 4, 'unit': 'ounce'},
-        ],
+        'quantity': [{
+            'amount': 2,
+            'unit': 'pound'
+        }, {
+            'amount': 4,
+            'unit': 'ounce'
+        }],
         'ingredient': 'potatoes',
     },
     '1-1/2 ounce vanilla ice cream': {
-        'quantity': {
+        'quantity': [{
             'amount': 1.5,
             'unit': 'ounce'
-        },
+        }],
         'ingredient': 'vanilla ice cream',
     },
     '1-½ ounce vanilla ice cream': {
-        'quantity': {
+        'quantity': [{
             'amount': 1.5,
             'unit': 'ounce'
-        },
+        }],
         'ingredient': 'vanilla ice cream',
     },
     'apple': {
@@ -267,24 +273,24 @@ test_cases = {
         'ingredient': 'apple',
     },
     '3-⅝ ounces, weight feta cheese, crumbled/diced': {
-        'quantity': {
+        'quantity': [{
             'amount': 3.625,
             'unit': 'ounce'
-        },
+        }],
         'ingredient': 'weight feta cheese, crumbled/diced',
     },
     '16-ounce can of sliced pineapple': {
-        'quantity': {
+        'quantity': [{
             'amount': 16,
             'unit': 'ounce'
-        },
+        }],
         'ingredient': 'can of sliced pineapple',
     },
     '750ml/1 pint 7fl oz hot vegetable stock': {
-        'quantity': {
+        'quantity': [{
             'amount': 750,
             'unit': 'milliliter'
-        },
+        }],
         'ingredient': 'hot vegetable stock',
     },
 }

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -241,6 +241,13 @@ test_cases = {
         ],
         'ingredient': 'potatoes',
     },
+    '2lb 4oz (1kg) potatoes': {
+        'quantity': [
+            {'amount': 2, 'unit': 'pound'},
+            {'amount': 4, 'unit': 'ounce'},
+        ],
+        'ingredient': 'potatoes',
+    },
     '1-1/2 ounce vanilla ice cream': {
         'quantity': {
             'amount': 1.5,

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -7,199 +7,271 @@ from ingreedypy import Ingreedy
 
 test_cases = {
     '1.0 cup flour': {
-        'amount': 1,
+        'quantity': {
+            'amount': 1.0,
+            'unit': 'cup'
+        },
         'ingredient': 'flour',
-        'unit': 'cup',
     },
     '1 1/2 cups flour': {
-        'amount': 1.5,
+        'quantity': {
+            'amount': 1.5,
+            'unit': 'cup'
+        },
         'ingredient': 'flour',
-        'unit': 'cup',
     },
     '1 1/2 potatoes': {
-        'amount': 1.5,
+        'quantity': {
+            'amount': 1.5,
+            'unit': None
+        },
         'ingredient': 'potatoes',
-        'unit': None,
     },
     '12345 potatoes': {
-        'amount': 12345,
+        'quantity': {
+            'amount': 12345,
+            'unit': None
+        },
         'ingredient': 'potatoes',
-        'unit': None,
     },
     '1 2/3 cups flour': {
-        'amount':  round(float(5.0/3), 3),
+        'quantity': {
+            'amount': round(float(5.0/3), 3),
+            'unit': 'cup'
+        },
         'ingredient': 'flour',
-        'unit': 'cup',
     },
     '12 (6-ounce) boneless skinless chicken breasts': {
-        'amount': 72,
+        'quantity': {
+            'amount': 72,
+            'unit': 'ounce'
+        },
         'ingredient': 'boneless skinless chicken breasts',
-        'unit': 'ounce',
     },
     '1 (28 ounce) can crushed tomatoes': {
-        'amount': 28,
+        'quantity': {
+            'amount': 28,
+            'unit': 'ounce'
+        },
         'ingredient': 'can crushed tomatoes',
-        'unit': 'ounce',
     },
     '1/2 cups flour': {
-        'amount': 0.5,
+        'quantity': {
+            'amount': 0.5,
+            'unit': 'cup'
+        },
         'ingredient': 'flour',
-        'unit': 'cup',
     },
     '12g potatoes': {
-        'amount': 12,
+        'quantity': {
+            'amount': 12,
+            'unit': 'gram'
+        },
         'ingredient': 'potatoes',
-        'unit': 'gram',
     },
     '12oz potatoes': {
-        'amount': 12,
+        'quantity': {
+            'amount': 12,
+            'unit': 'ounce'
+        },
         'ingredient': 'potatoes',
-        'unit': 'ounce',
     },
     '12oz tequila': {
-        'amount': 12,
+        'quantity': {
+            'amount': 12,
+            'unit': 'ounce'
+        },
         'ingredient': 'tequila',
-        'unit': 'ounce',
     },
     '1/2 potato': {
-        'amount': 0.5,
+        'quantity': {
+            'amount': 0.5,
+            'unit': None
+        },
         'ingredient': 'potato',
-        'unit': None,
     },
     '1.5 cups flour': {
-        'amount': 1.5,
+        'quantity': {
+            'amount': 1.5,
+            'unit': 'cup'
+        },
         'ingredient': 'flour',
-        'unit': 'cup',
     },
     '1.5 potatoes': {
-        'amount': 1.5,
+        'quantity': {
+            'amount': 1.5,
+            'unit': None
+        },
         'ingredient': 'potatoes',
-        'unit': None,
     },
     '1 clove garlic, minced': {
-        'amount': 1,
+        'quantity': {
+            'amount': 1,
+            'unit': None
+        },
         'ingredient': 'clove garlic, minced',
-        'unit': None,
     },
     '1 cup flour': {
-        'amount': 1,
+        'quantity': {
+            'amount': 1,
+            'unit': 'cup'
+        },
         'ingredient': 'flour',
-        'unit': 'cup',
     },
     '1 garlic clove, sliced in 1/2': {
-        'amount': 1,
+        'quantity': {
+            'amount': 1,
+            'unit': None
+        },
         'ingredient': 'garlic clove, sliced in 1/2',
-        'unit': None,
     },
     '1 tablespoon (3 teaspoons) Sazon seasoning blend (recommended: Goya) with Mexican and Spanish foods in market': {
-        'amount': 1,
+        'quantity': {
+            'amount': 1,
+            'unit': 'tablespoon'
+        },
         'ingredient': 'Sazon seasoning blend (recommended: Goya) with Mexican and Spanish foods in market',
-        'unit': 'tablespoon',
     },
     '2 (28 ounce) can crushed tomatoes': {
-        'amount': 56,
+        'quantity': {
+            'amount': 56,
+            'unit': 'ounce'
+        },
         'ingredient': 'can crushed tomatoes',
-        'unit': 'ounce',
     },
     '.25 cups flour': {
-        'amount': 0.25,
+        'quantity': {
+            'amount': 0.25,
+            'unit': 'cup'
+        },
         'ingredient': 'flour',
-        'unit': 'cup',
     },
     '2 cups of potatoes': {
-        'amount': 2,
+        'quantity': {
+            'amount': 2,
+            'unit': 'cup'
+        },
         'ingredient': 'potatoes',
-        'unit': 'cup',
     },
     '2 eggs, beaten': {
-        'amount': 2,
+        'quantity': {
+            'amount': 2,
+            'unit': None
+        },
         'ingredient': 'eggs, beaten',
-        'unit': None,
     },
     '3 28 ounce cans of crushed tomatoes': {
-        'amount': 84,
+        'quantity': {
+            'amount': 84,
+            'unit': 'ounce'
+        },
         'ingredient': 'cans of crushed tomatoes',
-        'unit': 'ounce',
     },
     '5 3/4 pinches potatoes': {
-        'amount': 5.75,
+        'quantity': {
+            'amount': 5.75,
+            'unit': 'pinch'
+        },
         'ingredient': 'potatoes',
-        'unit': 'pinch',
     },
     '.5 potatoes': {
-        'amount': 0.5,
+        'quantity': {
+            'amount': 0.5,
+            'unit': None
+        },
         'ingredient': 'potatoes',
-        'unit': None,
     },
     'a cup of flour': {
-        'amount': 1,
+        'quantity': {
+            'amount': 1,
+            'unit': 'cup'
+        },
         'ingredient': 'flour',
-        'unit': 'cup',
     },
     'ground black pepper to taste': {
-        'amount': None,
+        'quantity': None,
         'ingredient': 'ground black pepper to taste',
-        'unit': None,
     },
     'one 28 ounce can crushed tomatoes': {
-        'amount': 28,
+        'quantity': {
+            'amount': 28,
+            'unit': 'ounce'
+        },
         'ingredient': 'can crushed tomatoes',
-        'unit': 'ounce',
     },
     'one cup flour': {
-        'amount': 1,
+        'quantity': {
+            'amount': 1,
+            'unit': 'cup'
+        },
         'ingredient': 'flour',
-        'unit': 'cup',
     },
     'three 28 ounce cans crushed tomatoes': {
-        'amount': 84,
+        'quantity': {
+            'amount': 84,
+            'unit': 'ounce'
+        },
         'ingredient': 'cans crushed tomatoes',
-        'unit': 'ounce',
     },
     'two 28 ounce cans crushed tomatoes': {
-        'amount': [2, 28],
+        'quantity': {
+            'amount': 56,
+            'unit': 'ounce'
+        },
         'ingredient': 'cans crushed tomatoes',
-        'unit': 'ounce',
     },
     'two five ounce can crushed tomatoes': {
-        'amount': [2, 5],
+        'quantity': {
+            'amount': 10,
+            'unit': 'ounce'
+        },
         'ingredient': 'can crushed tomatoes',
-        'unit': 'ounce',
     },
     '1kg / 2lb 4oz potatoes': {
-        'amount': 1,
+        'quantity': {
+            'amount': 1,
+            'unit': 'kilogram'
+        },
         'ingredient': 'potatoes',
-        'unit': 'kilogram',
     },
     '2lb 4oz potatoes': {
-        'amount': [2, 4],
+        'quantity': [
+            {'amount': 2, 'unit': 'pound'},
+            {'amount': 4, 'unit': 'ounce'},
+        ],
         'ingredient': 'potatoes',
-        'unit': 'pound',
     },
     '1-1/2 ounce vanilla ice cream': {
-        'amount': 1.5,
+        'quantity': {
+            'amount': 1.5,
+            'unit': 'ounce'
+        },
         'ingredient': 'vanilla ice cream',
-        'unit': 'ounce',
     },
     '1-½ ounce vanilla ice cream': {
-        'amount': 1.5,
+        'quantity': {
+            'amount': 1.5,
+            'unit': 'ounce'
+        },
         'ingredient': 'vanilla ice cream',
-        'unit': 'ounce',
     },
     'apple': {
-        'amount': None,
+        'quantity': None,
         'ingredient': 'apple',
-        'unit': None,
     },
     '3-⅝ ounces, weight feta cheese, crumbled/diced': {
-        'amount': 3.625,
+        'quantity': {
+            'amount': 3.625,
+            'unit': 'ounce'
+        },
         'ingredient': 'weight feta cheese, crumbled/diced',
-        'unit': 'ounce'
     },
     '16-ounce can of sliced pineapple': {
-        'amount': 16,
+        'quantity': {
+            'amount': 16,
+            'unit': 'ounce'
+        },
         'ingredient': 'can of sliced pineapple',
-        'unit': 'ounce'
     },
 }
 

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -32,12 +32,12 @@ test_cases = {
         'unit': 'cup',
     },
     '12 (6-ounce) boneless skinless chicken breasts': {
-        'amount': [12, 6],
+        'amount': 72,
         'ingredient': 'boneless skinless chicken breasts',
         'unit': 'ounce',
     },
     '1 (28 ounce) can crushed tomatoes': {
-        'amount': [1, 28],
+        'amount': 28,
         'ingredient': 'can crushed tomatoes',
         'unit': 'ounce',
     },
@@ -97,7 +97,7 @@ test_cases = {
         'unit': 'tablespoon',
     },
     '2 (28 ounce) can crushed tomatoes': {
-        'amount': [2, 28],
+        'amount': 56,
         'ingredient': 'can crushed tomatoes',
         'unit': 'ounce',
     },
@@ -117,7 +117,7 @@ test_cases = {
         'unit': None,
     },
     '3 28 ounce cans of crushed tomatoes': {
-        'amount': [3, 28],
+        'amount': 84,
         'ingredient': 'cans of crushed tomatoes',
         'unit': 'ounce',
     },
@@ -142,7 +142,7 @@ test_cases = {
         'unit': None,
     },
     'one 28 ounce can crushed tomatoes': {
-        'amount': [1, 28],
+        'amount': 28,
         'ingredient': 'can crushed tomatoes',
         'unit': 'ounce',
     },
@@ -152,7 +152,7 @@ test_cases = {
         'unit': 'cup',
     },
     'three 28 ounce cans crushed tomatoes': {
-        'amount': [3, 28],
+        'amount': 84,
         'ingredient': 'cans crushed tomatoes',
         'unit': 'ounce',
     },

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -32,16 +32,14 @@ test_cases = {
         'unit': 'cup',
     },
     '12 (6-ounce) boneless skinless chicken breasts': {
-        'amount': 12,
+        'amount': [12, 6],
         'ingredient': 'boneless skinless chicken breasts',
         'unit': 'ounce',
-        'weight': 6,
     },
     '1 (28 ounce) can crushed tomatoes': {
-        'amount': 1,
+        'amount': [1, 28],
         'ingredient': 'can crushed tomatoes',
         'unit': 'ounce',
-        'weight': 28,
     },
     '1/2 cups flour': {
         'amount': 0.5,
@@ -97,13 +95,11 @@ test_cases = {
         'amount': 1,
         'ingredient': 'Sazon seasoning blend (recommended: Goya) with Mexican and Spanish foods in market',
         'unit': 'tablespoon',
-        'weight': 3,
     },
     '2 (28 ounce) can crushed tomatoes': {
-        'amount': 2,
+        'amount': [2, 28],
         'ingredient': 'can crushed tomatoes',
         'unit': 'ounce',
-        'weight': 28,
     },
     '.25 cups flour': {
         'amount': 0.25,
@@ -121,10 +117,9 @@ test_cases = {
         'unit': None,
     },
     '3 28 ounce cans of crushed tomatoes': {
-        'amount': 3,
+        'amount': [3, 28],
         'ingredient': 'cans of crushed tomatoes',
         'unit': 'ounce',
-        'weight': 28,
     },
     '5 3/4 pinches potatoes': {
         'amount': 5.75,
@@ -147,10 +142,9 @@ test_cases = {
         'unit': None,
     },
     'one 28 ounce can crushed tomatoes': {
-        'amount': 1,
+        'amount': [1, 28],
         'ingredient': 'can crushed tomatoes',
         'unit': 'ounce',
-        'weight': 28,
     },
     'one cup flour': {
         'amount': 1,
@@ -158,34 +152,29 @@ test_cases = {
         'unit': 'cup',
     },
     'three 28 ounce cans crushed tomatoes': {
-        'amount': 3,
+        'amount': [3, 28],
         'ingredient': 'cans crushed tomatoes',
         'unit': 'ounce',
-        'weight': 28,
     },
     'two 28 ounce cans crushed tomatoes': {
-        'amount': 2,
+        'amount': [2, 28],
         'ingredient': 'cans crushed tomatoes',
         'unit': 'ounce',
-        'weight': 28,
     },
     'two five ounce can crushed tomatoes': {
-        'amount': 2,
+        'amount': [2, 5],
         'ingredient': 'can crushed tomatoes',
         'unit': 'ounce',
-        'weight': 5,
     },
     '1kg / 2lb 4oz potatoes': {
         'amount': 1,
         'ingredient': 'potatoes',
         'unit': 'kilogram',
-        'weight': 4,
     },
     '2lb 4oz potatoes': {
-        'amount': 2,
+        'amount': [2, 4],
         'ingredient': 'potatoes',
         'unit': 'pound',
-        'weight': 4,
     },
     '1-1/2 ounce vanilla ice cream': {
         'amount': 1.5,
@@ -216,24 +205,7 @@ test_cases = {
 
 
 @pytest.mark.parametrize('description,expectation', test_cases.items())
-def test_amounts(description, expectation):
+def test_parser(description, expectation):
     result = Ingreedy().parse(description)
-    assert result['amount'] == expectation['amount']
-
-
-@pytest.mark.parametrize('description,expectation', test_cases.items())
-def test_unit(description, expectation):
-    result = Ingreedy().parse(description)
-    assert result['unit'] == expectation['unit']
-
-
-@pytest.mark.parametrize('description,expectation', test_cases.items())
-def test_ingredient(description, expectation):
-    result = Ingreedy().parse(description)
-    assert result['ingredient'] == expectation['ingredient']
-
-
-@pytest.mark.parametrize('description,expectation', test_cases.items())
-def test_weight(description, expectation):
-    result = Ingreedy().parse(description)
-    assert result.get('weight') == expectation.get('weight')
+    for key in expectation:
+        assert result[key] == expectation[key]

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -280,6 +280,13 @@ test_cases = {
         },
         'ingredient': 'can of sliced pineapple',
     },
+    '750ml/1 pint 7fl oz hot vegetable stock': {
+        'quantity': {
+            'amount': 750,
+            'unit': 'milliliter'
+        },
+        'ingredient': 'hot vegetable stock',
+    },
 }
 
 


### PR DESCRIPTION
Some ingredient lines -- particularly those containing imperial units such as `4lb 2oz potatoes` -- may contain multiple quantity fragments which contribute to a sum total for the ingredient.

As it stands, `ingreedy-py` does not perform any unit conversion, only unit parsing from text.

This changeset introduces a breaking change to the library interface which adds support for multi-part quantities.  The example given here would parse into two quantities for summation by the caller - `4 pounds` and `2 ounces`.

Todo:

- [x] Determine whether to *always* return a list type for the caller
- [x] Simplification/rectification of rule names
- [x] Major version bump post-release

Resolves #5 