### PR TITLE
Narrow down the number of cases where standalone units are valid

### DIFF
--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -72,7 +72,6 @@ class Ingreedy(NodeVisitor):
         quantity_fragment
         = quantity
         / amount
-        / single_unit
 
         alternative_quantity
         = ~"[/]" break? multipart_quantity
@@ -81,6 +80,7 @@ class Ingreedy(NodeVisitor):
         = amount_with_conversion
         / amount_with_attached_units
         / amount_with_multiplier
+        / amount_imprecise
 
         # 4lb (900g)
         amount_with_conversion
@@ -94,11 +94,12 @@ class Ingreedy(NodeVisitor):
         amount_with_multiplier
         = amount break? parenthesized_quantity
 
+        # pinch
+        amount_imprecise
+        = imprecise_unit !letter
+
         parenthesized_quantity
         = open amount_with_attached_units close
-
-        single_unit
-        = unit !letter
 
         amount
         = float
@@ -420,8 +421,8 @@ class Ingreedy(NodeVisitor):
         unit, system, amount = visited_children[2]
         return unit, system, amount * multiplier
 
-    def visit_single_unit(self, node, visited_children):
-        unit, system, _ = visited_children[0]
+    def visit_amount_imprecise(self, node, visited_children):
+        unit, system = visited_children[0]
         return unit, system, 1
 
     def visit_unit(self, node, visited_children):

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -342,6 +342,14 @@ test_cases = {
         }],
         'ingredient': 'salt',
     },
+    '4 (16 ounce) t-bone steaks, at room temperature': {
+        'quantity': [{
+            'amount': 64,
+            'unit': 'ounce',
+            'unit_type': 'english',
+        }],
+        'ingredient': 't-bone steaks, at room temperature',
+    },
 }
 
 


### PR DESCRIPTION
This change works under the premise that the following cases are valid and invalid:

**Valid**: `pinch salt, 1 tablespoon oil`
**Invalid**: `g salt, tbsp oil`

This isn't perfect; four recipes do contain `tsp <ingredient>` (ground nutmeg, ground cloves, and cinnamon) as ingredient lines, without any numeric value.  But this is fewer than the number of false positives found by considering the fragment `t` alone to be a quantity.  It may be possible to revisit this later.

Change: only consider 'imprecise' units to be valid as standalone units (i.e. in the absence of a quantifying `amount` value).