### PR TITLE
Make parsing of an ingredient element option

### DIFF
--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -64,7 +64,7 @@ class Ingreedy(NodeVisitor):
 
     grammar = Grammar(
         """
-        ingredient_addition = multipart_quantity alternative_quantity? break? ingredient
+        ingredient_addition = multipart_quantity alternative_quantity? break? ingredient?
 
         multipart_quantity
         = (quantity_fragment break?)*

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -350,6 +350,14 @@ test_cases = {
         }],
         'ingredient': 't-bone steaks, at room temperature',
     },
+    '5 g': {
+        'quantity': [{
+            'amount': 5,
+            'unit': 'gram',
+            'unit_type': 'metric',
+        }],
+        'ingredient': None,
+    }
 }
 
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This change allows strings that contain a quantity (or multiple quantity elements) without an ingredient name to parse.  For example, `10ml` parses to a quantity list containing `amount: 10` and `unit: milliliter`, `unit_type: metric`. 

### Briefly summarize the changes
1. Make the `ingredient` token optional in the grammar

### How have the changes been tested?
1. Test coverage is provided