### PR TITLE
Handle parentheses in ingredients

### DIFF
--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -119,7 +119,16 @@ class Ingreedy(NodeVisitor):
         / "-"
 
         ingredient
-        = word (break word)* catch_all
+        = (thing+) catch_all
+
+        thing
+        = word
+        / parenthesized_stuff
+        / amount
+        / break
+
+        parenthesized_stuff
+        = open thing* close
 
         open = "("
         close = ")"

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -398,6 +398,22 @@ test_cases = {
         }],
         'ingredient': None,
     },
+    '6 (thinly sliced) bananas': {
+        'quantity': [{
+            'amount': 6,
+            'unit': None,
+            'unit_type': None,
+        }],
+        'ingredient': '(thinly sliced) bananas',
+    },
+    '6 (1/4 inch thick) slices Italian bread': {
+        'quantity': [{
+            'amount': 6,
+            'unit': None,
+            'unit_type': None,
+        }],
+        'ingredient': '(1/4 inch thick) slices Italian bread',
+    },
 }
 
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Attempt to fix an ingredient which was parsed incorrectly because the ingredient description contained parentheses (#11).

### Briefly summarize the changes
1. Add a couple of test cases for ingredient descriptions which contain parentheses.
2. Adjust the parser grammar so that the new test cases pass, without introducing any other failures.

### How have the changes been tested?
1. By running the test suite

**List any issues that this change relates to**
Fixes #11.
