### PR TITLE
Handle parenthesized ingredient properties that are mentioned directly after initial quantities

### DIFF
--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -81,6 +81,7 @@ class Ingreedy(NodeVisitor):
         / amount_with_attached_units
         / amount_with_multiplier
         / amount_imprecise
+        / amount_with_other
 
         # 4lb (900g)
         amount_with_conversion
@@ -98,8 +99,15 @@ class Ingreedy(NodeVisitor):
         amount_imprecise
         = imprecise_unit !letter
 
+        # two (thinly sliced)
+        amount_with_other
+        = amount break? parenthesized_other?
+
         parenthesized_quantity
         = open amount_with_attached_units close
+
+        parenthesized_other
+        = open amount? word? (break word)* close
 
         amount
         = float

--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -80,8 +80,8 @@ class Ingreedy(NodeVisitor):
         = amount_with_conversion
         / amount_with_attached_units
         / amount_with_multiplier
+        / amount_with_property
         / amount_imprecise
-        / amount_with_other
 
         # 4lb (900g)
         amount_with_conversion
@@ -95,19 +95,23 @@ class Ingreedy(NodeVisitor):
         amount_with_multiplier
         = amount break? parenthesized_quantity
 
+        # four (1/2 size)
+        amount_with_property
+        = amount break? parenthesized_property
+
         # pinch
         amount_imprecise
         = imprecise_unit !letter
 
         # two (thinly sliced)
-        amount_with_other
-        = amount break? parenthesized_other?
+        amount_with_property
+        = amount break? parenthesized_property
 
         parenthesized_quantity
         = open amount_with_attached_units close
 
-        parenthesized_other
-        = open amount? word? (break word)* close
+        parenthesized_property
+        = open amount? break? word (break word)* close
 
         amount
         = float

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -398,6 +398,22 @@ test_cases = {
         }],
         'ingredient': None,
     },
+    '6 (thinly sliced) bananas': {
+        'quantity': [{
+            'amount': 6,
+            'unit': None,
+            'unit_type': None,
+        }],
+        'ingredient': 'bananas',
+    },
+    '6 (1/4 inch thick) slices Italian bread': {
+        'quantity': [{
+            'amount': 6,
+            'unit': None,
+            'unit_type': None,
+        }],
+        'ingredient': 'slices Italian bread',
+    },
 }
 
 

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -406,7 +406,7 @@ test_cases = {
         }],
         'ingredient': 'bananas',
     },
-    '6 (1/4 inch thick) slices Italian bread': {
+    '6 (1/2 inch thick) slices Italian bread': {
         'quantity': [{
             'amount': 6,
             'unit': None,


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This is an alternative approach to resolving #11.

### Briefly summarize the changes
1. Add a rule that handles a parenthesized 'property' of an ingredient (`four (example-property-here) onions`) 

### How have the changes been tested?
1. Unit test coverage has been updated

**List any issues that this change relates to**
Pull request #12 also provides a similar solution (and thanks @Thra11 for authoring and prototyping both of these solutions).