### PR TITLE
Fix: allow a single percentage-based descriptor in ingredient names

### DIFF
--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -131,7 +131,8 @@ class Ingreedy(NodeVisitor):
         / "-"
 
         ingredient
-        = word (break word)* catch_all
+        = (word (break word)* catch_all)
+        / (percentage ~"[- ]" word (break word)* catch_all)
 
         open = "("
         close = ")"
@@ -153,7 +154,12 @@ class Ingreedy(NodeVisitor):
         = integer ~"[/⁄]" integer
 
         integer
-        = ~"[0-9]+"
+        = ~"[0-9]+" !"%"
+
+        percentage
+        = ~"[1][0][0][%]"
+        / ~"[1-9][0-9][%]"
+        / ~"[0-9][%]"
 
         letter
         = ~"[a-zA-Z]"

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -422,6 +422,14 @@ test_cases = {
         }],
         'ingredient': 'orange',
     },
+    '2 cups 1%-fat milk': {
+        'quantity': [{
+            'amount': 2,
+            'unit': 'cup',
+            'unit_type': 'english',
+        }],
+        'ingredient': '1%-fat milk',
+    },
 }
 
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This change allows an ingredient named `2% fat milk` to be identified correctly, where previously it could not.

### Briefly summarize the changes
1. Allow a single percentage-based descriptor prefix to appear in the `ingredient` name.

### How have the changes been tested?
1. Unit test coverage is provided.

**List any issues that this change relates to**
Fixes #14.