### PR TITLE
Feature: begin supporting two-or-three character `abbreviated` units

### DIFF
--- a/ingreedypy.py
+++ b/ingreedypy.py
@@ -174,6 +174,7 @@ class Ingreedy(NodeVisitor):
         = english_unit
         / metric_unit
         / imprecise_unit
+        / abbreviated_unit
 
         english_unit
         = calorie
@@ -320,6 +321,9 @@ class Ingreedy(NodeVisitor):
         / pinch
         / touch
 
+        abbreviated_unit
+        = letter letter letter?
+
         dash
         = "dashes"
         / "dash"
@@ -408,6 +412,9 @@ class Ingreedy(NodeVisitor):
 
     def visit_english_unit(self, node, visited_children):
         return node.children[0].expr_name, 'english'
+
+    def visit_abbreviated_unit(self, node, visited_children):
+        return node.text, 'abbreviated'
 
     def visit_integer(self, node, visited_children):
         return int(node.text)

--- a/ingreedytest.py
+++ b/ingreedytest.py
@@ -430,6 +430,14 @@ test_cases = {
         }],
         'ingredient': '1%-fat milk',
     },
+    '2 PL cukr': {
+        'quantity': [{
+            'amount': 2,
+            'unit': 'PL',
+            'unit_type': 'abbreviated',
+        }],
+        'ingredient': 'cukr',
+    },
 }
 
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Indirectly, this allows parsing of abbreviated spoon units in Czech and Slovak.

### Briefly summarize the changes
1. Allow matching two-or-three-character unit labels in ingredient lines.
1. Return a `unit_type` of `abbreviated` in these cases.

### How have the changes been tested?
1. Unit test coverage is provided.

**List any issues that this change relates to**
Resolves #16.